### PR TITLE
ci: run GH_PAT update every 6 hours

### DIFF
--- a/.github/workflows/token.yml
+++ b/.github/workflows/token.yml
@@ -2,7 +2,7 @@ name: Set GH_PAT Secret
  
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: 0 */6 * * *
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
By default, the user access token expires after 8 hours. You can use a refresh token to regenerate a user access token. For more information, see [Refreshing user access tokens](https://docs.github.com/en/enterprise-server@3.13/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens).