### PR TITLE
feat: use REEARTH_CLASSIC_BEARER_TOKEN

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -4,8 +4,12 @@ repo: status
 sites:
   - name: Re:Earth Classic
     url: $REEARTH_CLASSIC_WEB_URL
+    headers:
+      - "Authorization: Bearer $REEARTH_CLASSIC_BEARER_TOKEN"
   - name: Re:Earth Classic API
     url: $REEARTH_CLASSIC_API_URL
+    headers:
+      - "Authorization: Bearer $REEARTH_CLASSIC_BEARER_TOKEN"
   - name: Re:Earth CMS
     url: $REEARTH_CMS_WEB_URL
     headers:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated uptime monitoring configuration to include HTTP authorization headers for "Re:Earth Classic" and "Re:Earth Classic API" sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->