### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: status
+  namespace: reearth
+  description: 📈 Uptime monitor and status page for reearth, powered by @upptime
+  annotations:
+    github.com/project-slug: reearth/status
+  links:
+  - url: https://github.com/reearth/status
+    title: GitHub
+    icon: github
+  - url: https://status.reearth.io
+    title: Website
+    icon: web
+  tags:
+  - markdown
+  - status-page
+  - upptime
+  - uptime-monitor
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/sre


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `status` (namespace `reearth`)
- **Owner:** `reearth/sre`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.